### PR TITLE
Update requirements in setup.py to include jinja2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,6 @@ setup(
         'PyYAML==3.11',
         'awesome-slugify==1.5',
         'markdown==2.4.1',
+        'Jinja2==2.7.3',
     ],
 )


### PR DESCRIPTION
Beetle fails to build due to a missing requirement when running `pip install -e .`
