### PR TITLE
Provide an empty list as default value for plugins

### DIFF
--- a/beetle/base.py
+++ b/beetle/base.py
@@ -17,7 +17,7 @@ class Config:
             self.folders.update(data.get('folders', {}))
             self.site.update(data.get('site', {}))
             self.page_defaults.update(data.get('page_defaults', {}))
-            self.plugins = data.get('plugins')
+            self.plugins = data.get('plugins', [])
 
     @classmethod
     def from_path(cls, path):


### PR DESCRIPTION
Otherwise, if you have a config.yaml file and don't specify any plugins in it, beetle will fail because the iterator in cli.py is iterating over None.
