### PR TITLE
PEP8 and Pylint clean up

### DIFF
--- a/beetle/base.py
+++ b/beetle/base.py
@@ -1,5 +1,6 @@
 import yaml
 
+
 class Config:
     def __init__(self, data):
         self.folders = {

--- a/beetle/builder.py
+++ b/beetle/builder.py
@@ -1,4 +1,4 @@
-from .renderers import ContentRenderer, TemplateRenderer
+from .renderers import TemplateRenderer
 from . import version, project_url, name
 from slugify import slugify
 from collections import defaultdict
@@ -6,6 +6,7 @@ from datetime import datetime
 import yaml
 import distutils.core
 import os
+
 
 class GroupKey:
     def __init__(self, name, slug):
@@ -57,7 +58,7 @@ class Builder:
         copy_include_folder(self.folders['include'], self.folders['output'])
 
     def page_paths(self):
-        for folder, folders, files in os.walk(self.folders['content']):
+        for folder, _, files in os.walk(self.folders['content']):
             for file_name in files:
                 yield os.path.join(folder, file_name)
 

--- a/beetle/cli.py
+++ b/beetle/cli.py
@@ -3,7 +3,7 @@ from .builder import Builder
 from .base import Config
 from .renderers import ContentRenderer
 import sys
-import os
+
 
 class Commander:
     commands = {}

--- a/beetle/renderers.py
+++ b/beetle/renderers.py
@@ -1,5 +1,4 @@
 from jinja2 import Environment, FileSystemLoader
-import markdown
 import os
 
 
@@ -14,7 +13,7 @@ class TemplateRenderer:
 
     def load_templates(self):
         for template_file in os.listdir(self.template_folder):
-            name, extension = os.path.splitext(template_file)
+            name, _ = os.path.splitext(template_file)
             yield name, self.env.get_template(template_file)
 
     def render_page(self, page, site):

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(
     install_requires=[
         'PyYAML==3.11',
         'awesome-slugify==1.5',
-        'markdown==2.4.1',
         'Jinja2==2.7.3',
     ],
 )


### PR DESCRIPTION
Removes some unused imports (and the dependency on markdown), plus adds some newlines where PEP8 dictates them.
