### PR TITLE
Handle unicode characters when reading from files

### DIFF
--- a/beetle/utils.py
+++ b/beetle/utils.py
@@ -2,10 +2,15 @@ import os
 
 
 def read_folder(folder, mode):
+    if 'b' in mode:
+        encoding = None
+    else:
+        encoding = 'utf-8'
+
     for folder, __, files in os.walk(folder):
         for file_name in files:
             path = os.path.join(folder, file_name)
-            with open(path, mode) as fo:
+            with open(path, mode, encoding=encoding) as fo:
                 yield path, fo.read()
 
 


### PR DESCRIPTION
I have a blog post containing the Danish letter 'ø', and when I render the site I get the error message:

```
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 453: ordinal not in range(128)
```

This pull request changes the `open()` call to specify UTF-8 as the encoding if reading from a file which isn't opened in binary mode, and that solves the problem.
