### PR TITLE
Avoid error message when cleaning with non-existing output folder

### DIFF
--- a/beetle/cli.py
+++ b/beetle/cli.py
@@ -9,7 +9,11 @@ import os
 
 def cleaner(folders):
     def clean():
-        shutil.rmtree(folders['output'])
+        try:
+            shutil.rmtree(folders['output'])
+        except FileNotFoundError:
+            pass
+
         os.mkdir(folders['output'])
     return clean
 


### PR DESCRIPTION
It avoids an exception when `beetle clean` is ran while the output directory doesn't exist.
